### PR TITLE
Add certification links to wythwin.md

### DIFF
--- a/src/content/builders/wythwin.md
+++ b/src/content/builders/wythwin.md
@@ -8,6 +8,9 @@ repo: https://github.com/wythwin
 x: waiyanthwin
 linkedin: waiyanthwin
 website: https://blog.waiyanthwin.com
+certs:
+  claude_101: https://verify.skilljar.com/c/bqxyfumtey2e
+  claude_code_101: https://verify.skilljar.com/c/YYYYYYYY
 ---
 
 Hi! I'm learning to vibe-code with AI. My goal is to build and ship something


### PR DESCRIPTION
Added certification links for Claude 101 courses.

<!-- Builder PR? Check the boxes below. Other PRs: delete this template. -->

## Adding myself as a Builder

- [x] Added **one** file: `src/content/builders/<my-github-username>.md`
- [x] Filename matches my `github:` value
- [x] Filled `name`, `github`, `cohort`
- [x] Wrote a 2–3 sentence intro below the frontmatter
- [x] Did **not** change any other files

<!-- See BUILDERS.md for the full guide. -->
