### PR TITLE
Add certification links to ThantZ-cloud.md

### DIFF
--- a/src/content/builders/ThantZ-cloud.md
+++ b/src/content/builders/ThantZ-cloud.md
@@ -8,7 +8,12 @@ skills: ["JavaScript", "Typescript","Java","React","Nextjs","Mysql","Express","R
 
 Hi! I'm learning to vibe-code with AI. My goal is to build and ship something
 real by Demo Day. Excited to be part of the Tour.
-
+certs:
+  claude_101: https://verify.skilljar.com/c/jkr99zn89nvx
+  claude_code_101: https://verify.skilljar.com/c/gi9o7vhadwkb
+  agent_skills_intro: https://verify.skilljar.com/c/m5a5ztoz5mvw
+  subagents_intro: https://verify.skilljar.com/c/tdkf6gtdwgkf
+  mcp_intro: https://verify.skilljar.com/c/a8axyfjnw2g2
 <!--
 HOW TO ADD YOURSELF:
 1. Copy this file to src/content/builders/<your-github-username>.md


### PR DESCRIPTION
Added certification links for various courses.

<!-- Builder PR? Check the boxes below. Other PRs: delete this template. -->

## Adding myself as a Builder

- [ ] Added **one** file: `src/content/builders/<my-github-username>.md`
- [ ] Filename matches my `github:` value
- [ ] Filled `name`, `github`, `cohort`
- [ ] Wrote a 2–3 sentence intro below the frontmatter
- [ ] Did **not** change any other files

<!-- See BUILDERS.md for the full guide. -->
