### PR TITLE
Fix Team-18 (Fraud Awareness Hub) live URL

### DIFF
--- a/src/data/teams.json
+++ b/src/data/teams.json
@@ -281,7 +281,7 @@
     "drive_url": null,
     "drive_id": null,
     "uploaded": "Done",
-    "live_url": "https://fraud-awareness-hub-hpa6.vercel.app/",
+    "live_url": "https://fraud-awareness-hub-sable.vercel.app/",
     "repo_url": "https://github.com/swan1792/Fraud_Awareness_Hub.git",
     "notes": null,
     "type": "web-app",


### PR DESCRIPTION
Updates Team-18's live URL from `https://fraud-awareness-hub-hpa6.vercel.app/` to the correct `https://fraud-awareness-hub-sable.vercel.app/`.

**File changed:** `src/data/teams.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)