### PR TITLE
fix(certs): resolve cert id aliases + document the short ids

### DIFF
--- a/BUILDERS.md
+++ b/BUILDERS.md
@@ -75,6 +75,52 @@ Social fields accept a handle (`kokoye2007`) or a full URL.
 - **No photo needed** — your GitHub avatar is pulled automatically.
 - `role`: leave as `builder` (mentors/instructors set their own).
 
+### 4b. Add your certificates (optional)
+
+Finished a Claude course? Add a `certs:` block and the badge lights up amber on
+your card. Two rules: it goes **under `certs:`, indented 2 spaces**, and you use
+the **short id** — not the course title.
+
+```yaml
+certs:
+  claude_101: 293x3v9qydhx
+  claude_code_101: https://verify.skilljar.com/c/sbdx5cwzjhec
+  agent_skills_intro: https://verify.skilljar.com/c/kfnmyubu3i96
+```
+
+The value is either the bare Skilljar code or the full verify URL — both work.
+Find it on your certificate page: the link ends in `/c/<your-code>`.
+
+**Short id for every cert we track:**
+
+| Course name (as shown on Skilljar)     | Short id to write          |
+| -------------------------------------- | -------------------------- |
+| Claude 101                             | `claude_101`               |
+| Claude Code 101                        | `claude_code_101`          |
+| Introduction to Agent Skills           | `agent_skills_intro`       |
+| Introduction to Subagents              | `subagents_intro`          |
+| Introduction to Model Context Protocol | `mcp_intro`                |
+| Claude Code in Action                  | `claude_code_in_action`    |
+| Building with the Claude API           | `building_claude_api`      |
+| Claude Platform 101                    | `claude_platform_101`      |
+| Introduction to Claude Cowork          | `claude_cowork`            |
+| MCP: Advanced Topics                   | `mcp_advanced`             |
+| Claude with Amazon Bedrock             | `claude_bedrock`           |
+| Claude with Vertex AI                  | `claude_vertex`            |
+| AI Fluency: Framework & Foundations    | `ai_fluency`               |
+| AI Fluency for Educators               | `ai_fluency_for_educators` |
+| GitHub Foundations (Credly)            | `github_foundations`       |
+| Git Essential Training (LinkedIn)      | `git_essential_training`   |
+
+Non-Skilljar certs (GitHub Foundations, Git Essential Training) use the full
+public verify URL as the value — Credly badge link, LinkedIn certificate link.
+
+> **Wrote the course title instead?** It still works. `Introduction to subagents`,
+> `introduction-to-subagents`, and `subagents_intro` all resolve to the same badge —
+> case, spaces, and hyphens don't matter. CI will just nudge you toward the short
+> id. What does **not** work is putting cert ids at the top level instead of under
+> `certs:` — those are silently ignored.
+
 ### 5. Commit
 
 ```bash
@@ -172,6 +218,56 @@ handle (`kokoye2007`) ဒါမှမဟုတ် URL အပြည့် လက�
 - `name`, `github`, `cohort` မဖြစ်မနေ လိုအပ်တယ်။ `repo` က optional။
 - **ဓာတ်ပုံ မလိုပါ** — သင့် GitHub avatar ကို အလိုအလျောက် ဆွဲယူပါမယ်။
 - `role` ကို `builder` အတိုင်း ထားပါ။
+
+### ၄-ခ။ လက်မှတ် (certificate) ထည့်ခြင်း — optional
+
+Claude သင်တန်း ပြီးထားပြီလား? `certs:` block ထည့်လိုက်ရင် သင့် card ပေါ်မှာ
+badge က အဝါရောင် လင်းလာပါမယ်။ စည်းမျဉ်း နှစ်ခုပဲ ရှိတယ် — `certs:` **အောက်မှာ
+space ၂ လုံး ခြားပြီး** ရေးရမယ်၊ ပြီးတော့ သင်တန်းနာမည်အပြည့် မဟုတ်ဘဲ
+**short id** ကို သုံးရမယ်။
+
+```yaml
+certs:
+  claude_101: 293x3v9qydhx
+  claude_code_101: https://verify.skilljar.com/c/sbdx5cwzjhec
+  agent_skills_intro: https://verify.skilljar.com/c/kfnmyubu3i96
+```
+
+တန်ဖိုးက Skilljar code သက်သက်ဖြစ်ဖြစ်၊ verify URL အပြည့်ဖြစ်ဖြစ် ရပါတယ် —
+နှစ်မျိုးလုံး အလုပ်လုပ်တယ်။ သင့် certificate စာမျက်နှာမှာ link အဆုံးက
+`/c/<your-code>` ဆိုတာ ရှာပါ။
+
+**Cert တိုင်းအတွက် short id —**
+
+| သင်တန်းနာမည် (Skilljar မှာ ပြထားသည့်အတိုင်း) | ရေးရမည့် short id          |
+| -------------------------------------------- | -------------------------- |
+| Claude 101                                   | `claude_101`               |
+| Claude Code 101                              | `claude_code_101`          |
+| Introduction to Agent Skills                 | `agent_skills_intro`       |
+| Introduction to Subagents                    | `subagents_intro`          |
+| Introduction to Model Context Protocol       | `mcp_intro`                |
+| Claude Code in Action                        | `claude_code_in_action`    |
+| Building with the Claude API                 | `building_claude_api`      |
+| Claude Platform 101                          | `claude_platform_101`      |
+| Introduction to Claude Cowork                | `claude_cowork`            |
+| MCP: Advanced Topics                         | `mcp_advanced`             |
+| Claude with Amazon Bedrock                   | `claude_bedrock`           |
+| Claude with Vertex AI                        | `claude_vertex`            |
+| AI Fluency: Framework & Foundations          | `ai_fluency`               |
+| AI Fluency for Educators                     | `ai_fluency_for_educators` |
+| GitHub Foundations (Credly)                  | `github_foundations`       |
+| Git Essential Training (LinkedIn)            | `git_essential_training`   |
+
+Skilljar မဟုတ်တဲ့ cert တွေ (GitHub Foundations, Git Essential Training) ကတော့
+verify URL အပြည့် — Credly badge link ဒါမှမဟုတ် LinkedIn certificate link —
+ကို တန်ဖိုးအဖြစ် ထည့်ပါ။
+
+> **သင်တန်းနာမည်အပြည့် ရေးမိပြီလား?** ရပါတယ်၊ အလုပ်လုပ်ပါတယ်။
+> `Introduction to subagents`၊ `introduction-to-subagents`၊ `subagents_intro`
+> သုံးခုလုံး badge တစ်ခုတည်းကို ညွှန်ပါတယ် — စာလုံးအကြီးအသေး၊ space၊ hyphen
+> အရေးမကြီးပါ။ CI က short id သုံးဖို့ သတိပေးရုံပါပဲ။ **အလုပ်မလုပ်တာ** ကတော့
+> cert id တွေကို `certs:` အောက်မှာ မထားဘဲ အပေါ်ဆုံး အဆင့်မှာ ထားလိုက်တာ —
+> အဲဒါဆို တိတ်တိတ်ဆိတ်ဆိတ် ပျောက်သွားပါလိမ့်မယ်။
 
 ### ၅။ Commit
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check": "astro check",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test": "node --test src/lib/*.test.mjs",
     "validate:builders": "node scripts/validate-builders.mjs",
     "verify:certs": "node scripts/verify-certs.mjs",
     "hero:mosaic": "node scripts/hero/build-mosaic.mjs",

--- a/scripts/validate-builders.mjs
+++ b/scripts/validate-builders.mjs
@@ -8,7 +8,7 @@ import {
   identityProblems,
   normalizeGithub,
 } from "../src/lib/builder-identity.mjs";
-import { CERT_CATALOG } from "../src/lib/certs.mjs";
+import { CERT_CATALOG, canonicalCertId } from "../src/lib/certs.mjs";
 
 // Forward-only filename rule: a builder file MUST be named <github-handle>.md so
 // filename, frontmatter github, and the level key (levels.json is keyed by
@@ -133,10 +133,11 @@ for (const f of files) {
   for (const key of Object.keys(data)) {
     if (SCHEMA_KEYS.has(key)) continue;
     const lc = key.toLowerCase();
-    if (CERT_IDS.has(key))
+    if (CERT_IDS.has(canonicalCertId(key)))
       warnings.push(
         `${f}: '${key}' is a Claude cert id at the TOP LEVEL — it won't show. ` +
-          `Nest it under a 'certs:' block (certs: then indented '${key}: <code>').`,
+          `Nest it under a 'certs:' block (certs: then indented ` +
+          `'${canonicalCertId(key)}: <code>').`,
       );
     else if (FIELD_ALIASES[lc])
       warnings.push(
@@ -145,17 +146,27 @@ for (const f of files) {
     else
       warnings.push(`${f}: unrecognized key '${key}' — this field is ignored.`);
   }
-  // certs present but a child id is not in the catalog → likely typo (still renders w/ default label)
+  // A cert id that isn't the canonical spelling still renders (aliases resolve at
+  // build time) — say so, and name the id to use. One that resolves to nothing is
+  // a likely typo and renders with a default label instead of its real badge.
   if (
     data.certs &&
     typeof data.certs === "object" &&
     !Array.isArray(data.certs)
   ) {
-    for (const cid of Object.keys(data.certs))
-      if (!CERT_IDS.has(cid))
+    for (const cid of Object.keys(data.certs)) {
+      if (CERT_IDS.has(cid)) continue;
+      const canonical = canonicalCertId(cid);
+      if (CERT_IDS.has(canonical))
+        warnings.push(
+          `${f}: cert id '${cid}' resolves to '${canonical}' — it displays correctly, ` +
+            `but prefer the short id '${canonical}' (see BUILDERS.md).`,
+        );
+      else
         warnings.push(
           `${f}: cert id '${cid}' not in catalog — check spelling (renders with a default label).`,
         );
+    }
   }
 }
 

--- a/scripts/verify-certs.mjs
+++ b/scripts/verify-certs.mjs
@@ -8,7 +8,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import yaml from "js-yaml";
-import { normalizeCerts, skilljarUrl } from "../src/lib/certs.mjs";
+import { normalizeCerts, certUrl } from "../src/lib/certs.mjs";
 
 const dir = "src/content/builders";
 const TIMEOUT_MS = 12000;
@@ -31,7 +31,8 @@ for (const f of fs
   const certs = normalizeCerts(data?.certs);
   if (!certs) continue;
   for (const [id, code] of Object.entries(certs)) {
-    jobs.push({ file: f, id, code, url: skilljarUrl(code) });
+    // certUrl, not skilljarUrl — non-Skilljar certs store a full URL as the code.
+    jobs.push({ file: f, id, code, url: certUrl(code) });
   }
 }
 

--- a/src/content/builders/_example.md
+++ b/src/content/builders/_example.md
@@ -21,17 +21,39 @@ HOW TO ADD YOURSELF
 4. OPTIONAL — add a line ONLY if you have one. Otherwise leave it out entirely.
    DO NOT leave blank or "your-..." placeholder values — just delete the line.
 
-   CLAUDE CERTIFICATIONS (optional) — add a `certs:` block with the ones you
-   earned. Value = the Skilljar code OR the full verify URL. Known ids:
-     claude_101, claude_code_101, agent_skills_intro, subagents_intro,
-     mcp_intro, claude_code_in_action, building_claude_api, claude_platform_101,
-     claude_cowork, mcp_advanced, claude_bedrock, claude_vertex, ai_fluency
+   CERTIFICATIONS (optional) — add a `certs:` block with the ones you earned.
+   Value = the Skilljar code OR the full verify URL. Use the SHORT ID on the
+   left, NOT the course title:
+
+     course on Skilljar                     ->  id to write
+     ------------------------------------------------------------
+     Claude 101                             ->  claude_101
+     Claude Code 101                        ->  claude_code_101
+     Introduction to Agent Skills           ->  agent_skills_intro
+     Introduction to Subagents              ->  subagents_intro
+     Introduction to Model Context Protocol ->  mcp_intro
+     Claude Code in Action                  ->  claude_code_in_action
+     Building with the Claude API           ->  building_claude_api
+     Claude Platform 101                    ->  claude_platform_101
+     Introduction to Claude Cowork          ->  claude_cowork
+     MCP: Advanced Topics                   ->  mcp_advanced
+     Claude with Amazon Bedrock             ->  claude_bedrock
+     Claude with Vertex AI                  ->  claude_vertex
+     AI Fluency: Framework & Foundations    ->  ai_fluency
+     AI Fluency for Educators               ->  ai_fluency_for_educators
+     GitHub Foundations (Credly)            ->  github_foundations
+     Git Essential Training (LinkedIn)      ->  git_essential_training
+
    Example:
      certs:
-       claude_101:      <skilljar-code>
-       claude_code_101: <verify-url>
-   Earned certs light up as colored stars on your card (grey = not yet).
-   ⚠ Cert ids go UNDER `certs:` (indented). At the top level they're ignored.
+       claude_101: 293x3v9qydhx
+       claude_code_101: https://verify.skilljar.com/c/sbdx5cwzjhec
+       github_foundations: https://www.credly.com/badges/<your-badge-id>
+
+   Earned certs light up as amber badges on your card (grey = not yet earned).
+   Writing the course title instead of the short id still works — it's mapped
+   automatically — but CI will nudge you toward the short id.
+   ⚠ Cert ids go UNDER `certs:` (indented 2 spaces). At the top level they're ignored.
      skills:   ["Python", "React", "MCP"]
      repo:     https://github.com/<you>/<your-project>
      x:        your-x-handle            (handle or full URL)

--- a/src/content/builders/haymannko.md
+++ b/src/content/builders/haymannko.md
@@ -5,8 +5,9 @@ cohort: 1
 role: builder
 skills: ["AWS", "Docker", "DevOps"]
 linkedin: https://www.linkedin.com/in/hay-mann-ko-40a111277
-claude_101:      https://verify.skilljar.com/c/pr2dfnt2ng2b
-claude_code_101: https://verify.skilljar.com/c/oyugvv7fvoaq
+certs:
+  claude_101: https://verify.skilljar.com/c/pr2dfnt2ng2b
+  claude_code_101: https://verify.skilljar.com/c/oyugvv7fvoaq
 ---
 
 Hi! I'm enjoyable to contribute in Vibe Code Tours of Cohort 1. My goal is to use VibeTour knowledge in my career development.

--- a/src/content/builders/wythwin.md
+++ b/src/content/builders/wythwin.md
@@ -10,7 +10,6 @@ linkedin: waiyanthwin
 website: https://blog.waiyanthwin.com
 certs:
   claude_101: https://verify.skilljar.com/c/bqxyfumtey2e
-  claude_code_101: https://verify.skilljar.com/c/YYYYYYYY
 ---
 
 Hi! I'm learning to vibe-code with AI. My goal is to build and ship something

--- a/src/lib/certs.mjs
+++ b/src/lib/certs.mjs
@@ -69,11 +69,22 @@ export const CERT_CATALOG = {
     level: "beginner",
     order: 13,
   },
+  ai_fluency_for_educators: {
+    label: "AI Fluency for Educators",
+    level: "beginner",
+    order: 14,
+  },
   // Non-Skilljar: GitHub Foundations (official GitHub credential, verified on Credly).
   github_foundations: {
     label: "GitHub Foundations",
     level: "intermediate",
-    order: 14,
+    order: 15,
+  },
+  // Non-Skilljar: LinkedIn Learning (git fundamentals — Ch-1 of the Tour).
+  git_essential_training: {
+    label: "Git Essential Training",
+    level: "beginner",
+    order: 16,
   },
 };
 
@@ -117,9 +128,15 @@ export const CERT_ICONS = {
   // AI Fluency — open book
   ai_fluency:
     '<path d="M4 5a2 2 0 0 1 2-2h6v16H6a2 2 0 0 0-2 2zM20 5a2 2 0 0 0-2-2h-6v16h6a2 2 0 0 1 2 2z"/>',
+  // AI Fluency for Educators — graduation cap
+  ai_fluency_for_educators:
+    '<path d="M2 8l10-4 10 4-10 4z"/><path d="M6 10.5V16c0 1.8 2.7 3 6 3s6-1.2 6-3v-5.5M21 8v6"/>',
   // GitHub Foundations — git branch / merge
   github_foundations:
     '<circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="17" cy="8" r="2.5"/><path d="M6 8.5v7M17 10.5c0 3.6-5 2.4-11 4.5"/>',
+  // Git Essential Training — git commit node on a line
+  git_essential_training:
+    '<circle cx="12" cy="12" r="3.2"/><path d="M3 12h5.8M15.2 12H21"/>',
 };
 // Fallback — medal/seal for any unknown cert id.
 export const DEFAULT_ICON =
@@ -135,6 +152,11 @@ export const CERT_GREY = "#3f3f46";
 // Be tolerant: 6–24 alphanumerics.
 const CODE_RE = /^[A-Za-z0-9]{6,24}$/;
 
+// Template leftovers (XXXXXXXX, YYYYYYYY, 00000000) satisfy CODE_RE but 404 on
+// Skilljar — and an unearned cert that renders as "verified" is worse than one
+// that doesn't render at all. Drop any code that is one repeated character.
+const PLACEHOLDER_RE = /^([A-Za-z0-9])\1{5,}$/;
+
 // Extract the bare verification code from a code, a verify URL, or a [md](url).
 export function normalizeSkilljar(v) {
   if (v == null) return "";
@@ -145,7 +167,7 @@ export function normalizeSkilljar(v) {
   const m = t.match(/skilljar\.com\/c\/([A-Za-z0-9]+)/i); // full verify URL
   if (m) t = m[1];
   t = t.replace(/\/+$/, "");
-  return CODE_RE.test(t) ? t : "";
+  return CODE_RE.test(t) && !PLACEHOLDER_RE.test(t) ? t : "";
 }
 
 export const skilljarUrl = (code) => SKILLJAR_VERIFY_BASE + code;
@@ -163,7 +185,93 @@ function extractUrl(v) {
   let t = String(v).trim();
   const link = t.match(/^\[[^\]]*\]\(([^)]*)\)$/);
   if (link) t = link[1].trim();
+  // Skilljar URLs belong to normalizeSkilljar — if it rejected the code, this
+  // must not resurrect the URL as a "non-Skilljar cert".
+  if (/skilljar\.com/i.test(t)) return "";
   return /^https?:\/\/\S+$/.test(t) ? t : "";
+}
+
+// --- Cert id canonicalization ---------------------------------------------
+// Builders copy the id off the Skilljar course title, so every shape shows up:
+//   "Introduction to agent skills"  "introduction-to-agent-skills"
+//   "introduction_to_Model_Context_Protocol"  "AI_fluency_framework_&_foundations"
+// Three layers map those onto a catalog id. Anything still unresolved is kept
+// as-is (renders with a default label) and validate-builders warns about it.
+
+// 1. Shape — lowercase, every non-alphanumeric run becomes a single "_".
+export function slugifyCertId(v) {
+  return String(v ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+// 2. Wording — course-title phrasings that differ from the short id.
+// Keys must already be slugified. Case/spacing/punctuation variants need no
+// entry here; layer 1 folds them away first.
+export const CERT_ALIASES = {
+  // Intro to Agent Skills
+  agent_skills: "agent_skills_intro",
+  agentskills_intro: "agent_skills_intro",
+  introduction_to_agent_skills: "agent_skills_intro",
+  // Intro to Subagents
+  subagents: "subagents_intro",
+  introduction_to_subagents: "subagents_intro",
+  // Intro to MCP
+  mcp: "mcp_intro",
+  model_context_protocol: "mcp_intro",
+  introduction_to_mcp: "mcp_intro",
+  introduction_to_model_context_protocol: "mcp_intro",
+  introduction_to_model_context_protocol_mcp: "mcp_intro",
+  intro_to_model_context_protocol: "mcp_intro",
+  // MCP: Advanced Topics
+  advanced_mcp: "mcp_advanced",
+  mcp_advanced_topics: "mcp_advanced",
+  // AI Fluency: Foundations
+  ai_fluency_framework: "ai_fluency",
+  ai_fluency_framework_foundations: "ai_fluency",
+  ai_fluency_framework_and_foundations: "ai_fluency",
+  // AI Fluency for Educators
+  ai_fluency_educators: "ai_fluency_for_educators",
+  // Building with the Claude API
+  building_with_claude_api: "building_claude_api",
+  claude_api: "building_claude_api",
+  // Claude with Amazon Bedrock / Vertex AI
+  claude_on_amazon_bedrock: "claude_bedrock",
+  amazon_bedrock: "claude_bedrock",
+  claude_with_google_vertex_ai: "claude_vertex",
+  claude_on_vertex_ai: "claude_vertex",
+  vertex_ai: "claude_vertex",
+  // Intro to Claude Cowork
+  cowork: "claude_cowork",
+  claude_cowork_intro: "claude_cowork",
+  introduction_to_claude_cowork: "claude_cowork",
+  // Claude Platform 101
+  claude_platform: "claude_platform_101",
+  // GitHub Foundations
+  github_foundation: "github_foundations",
+  github_foundations_certification: "github_foundations",
+  // Git Essential Training (LinkedIn Learning)
+  git_essentials: "git_essential_training",
+  git_essentials_training: "git_essential_training",
+  git_essential: "git_essential_training",
+};
+
+// 3. Catalog label — auto-derived, so a renamed label keeps resolving.
+//    "Intro to MCP" -> intro_to_mcp, "Claude Code in Action" -> claude_code_in_action.
+const LABEL_SLUGS = Object.fromEntries(
+  Object.entries(CERT_CATALOG).map(([id, meta]) => [
+    slugifyCertId(meta.label),
+    id,
+  ]),
+);
+
+// Resolve any builder-written cert key to a catalog id. Returns the slugified
+// input unchanged when nothing matches (unknown certs still render).
+export function canonicalCertId(raw) {
+  const slug = slugifyCertId(raw);
+  if (!slug || CERT_CATALOG[slug]) return slug;
+  return CERT_ALIASES[slug] || LABEL_SLUGS[slug] || slug;
 }
 
 export function certMeta(id) {
@@ -176,19 +284,26 @@ export function certMeta(id) {
   );
 }
 
-// Normalize a raw `certs` frontmatter value into { id: code } with valid codes only.
+// Normalize a raw `certs` frontmatter value into { canonicalId: code }, keeping
+// only entries whose value is a usable Skilljar code or a non-Skilljar verify URL.
 export function normalizeCerts(raw) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
-  const out = {};
-  for (const [id, val] of Object.entries(raw)) {
-    const code = normalizeSkilljar(val);
-    if (code) {
-      out[String(id).trim()] = code;
-      continue;
+
+  const entries = [];
+  for (const [rawId, val] of Object.entries(raw)) {
+    // Skilljar code (or verify URL) first; else a non-Skilljar URL (e.g. Credly).
+    const code = normalizeSkilljar(val) || extractUrl(val);
+    const id = canonicalCertId(rawId);
+    if (code && id) {
+      entries.push({ id, code, exact: slugifyCertId(rawId) === id });
     }
-    const url = extractUrl(val); // non-Skilljar cert (e.g. GitHub Foundations)
-    if (url) out[String(id).trim()] = url;
   }
+
+  // A builder can list the same cert twice (short id + course title). The
+  // canonical spelling wins; otherwise first one listed wins.
+  const out = {};
+  for (const e of entries) if (e.exact && !(e.id in out)) out[e.id] = e.code;
+  for (const e of entries) if (!(e.id in out)) out[e.id] = e.code;
   return Object.keys(out).length ? out : undefined;
 }
 

--- a/src/lib/certs.test.mjs
+++ b/src/lib/certs.test.mjs
@@ -1,0 +1,132 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CERT_ALIASES,
+  CERT_CATALOG,
+  canonicalCertId,
+  certUrl,
+  normalizeCerts,
+  slugifyCertId,
+} from "./certs.mjs";
+
+// Every one of these is a real key a builder pushed to src/content/builders.
+const REAL_WORLD = {
+  "Introduction to agent skills": "agent_skills_intro",
+  "introduction-to-agent-skills": "agent_skills_intro",
+  introduction_to_agent_skills: "agent_skills_intro",
+  agent_skills: "agent_skills_intro",
+  "Introduction to subagents": "subagents_intro",
+  introduction_to_subagents: "subagents_intro",
+  introduction_to_Model_Context_Protocol: "mcp_intro",
+  introduction_to_model_context_protocol: "mcp_intro",
+  "AI Fluency Framework and Foundations": "ai_fluency",
+  "AI_fluency_framework_&_foundations": "ai_fluency",
+  "Claude_Platform 101": "claude_platform_101",
+  "claude-code-in-action": "claude_code_in_action",
+};
+
+test("slugifyCertId folds case, spaces, hyphens and punctuation", () => {
+  assert.equal(
+    slugifyCertId("Introduction to agent skills"),
+    "introduction_to_agent_skills",
+  );
+  assert.equal(
+    slugifyCertId("AI_fluency_framework_&_foundations"),
+    "ai_fluency_framework_foundations",
+  );
+  assert.equal(
+    slugifyCertId("  claude-code-in-action  "),
+    "claude_code_in_action",
+  );
+  assert.equal(slugifyCertId(""), "");
+  assert.equal(slugifyCertId(null), "");
+});
+
+test("canonicalCertId resolves every id builders have actually written", () => {
+  for (const [raw, expected] of Object.entries(REAL_WORLD)) {
+    assert.equal(canonicalCertId(raw), expected, `${raw} -> ${expected}`);
+  }
+});
+
+test("canonicalCertId resolves catalog labels (layer 3, auto-derived)", () => {
+  assert.equal(canonicalCertId("Intro to MCP"), "mcp_intro");
+  assert.equal(
+    canonicalCertId("Building with the Claude API"),
+    "building_claude_api",
+  );
+  assert.equal(canonicalCertId("Claude with Amazon Bedrock"), "claude_bedrock");
+  assert.equal(canonicalCertId("GitHub Foundations"), "github_foundations");
+});
+
+test("canonicalCertId leaves an unknown cert alone (slugified, still renders)", () => {
+  assert.equal(canonicalCertId("Some Other Course"), "some_other_course");
+});
+
+test("every alias target is a real catalog id", () => {
+  for (const [alias, target] of Object.entries(CERT_ALIASES)) {
+    assert.ok(
+      CERT_CATALOG[target],
+      `alias '${alias}' -> unknown id '${target}'`,
+    );
+    assert.equal(
+      slugifyCertId(alias),
+      alias,
+      `alias key '${alias}' is not slugified`,
+    );
+    assert.ok(!CERT_CATALOG[alias], `alias '${alias}' shadows a catalog id`);
+  }
+});
+
+test("catalog orders are unique", () => {
+  const orders = Object.values(CERT_CATALOG).map((m) => m.order);
+  assert.equal(new Set(orders).size, orders.length);
+});
+
+test("normalizeCerts canonicalizes ids and keeps Skilljar codes", () => {
+  const out = normalizeCerts({
+    "Introduction to subagents": "https://verify.skilljar.com/c/qaadufpgkrma",
+    introduction_to_Model_Context_Protocol: "g9t775dpv6bj",
+  });
+  assert.deepEqual(out, {
+    subagents_intro: "qaadufpgkrma",
+    mcp_intro: "g9t775dpv6bj",
+  });
+});
+
+test("normalizeCerts keeps a non-Skilljar verify URL intact", () => {
+  const url =
+    "https://www.linkedin.com/learning/certificates/ed41dc0684c8?trk=share_certificate";
+  const out = normalizeCerts({ git_essential_training: url });
+  assert.deepEqual(out, { git_essential_training: url });
+  assert.equal(certUrl(url), url);
+});
+
+test("normalizeCerts prefers the canonical spelling when a cert is listed twice", () => {
+  const out = normalizeCerts({
+    "Introduction to subagents": "mnkwxrfjaxyq",
+    subagents_intro: "qaadufpgkrma",
+  });
+  assert.deepEqual(out, { subagents_intro: "qaadufpgkrma" });
+});
+
+test("normalizeCerts drops entries with no usable code", () => {
+  assert.equal(normalizeCerts({ claude_101: "" }), undefined);
+  assert.equal(normalizeCerts({ claude_101: "<skilljar-code>" }), undefined);
+  assert.equal(normalizeCerts(null), undefined);
+  assert.equal(normalizeCerts(["claude_101"]), undefined);
+});
+
+test("normalizeCerts rejects template placeholder codes (fake 'verified' badge)", () => {
+  assert.equal(
+    normalizeCerts({
+      claude_code_101: "https://verify.skilljar.com/c/YYYYYYYY",
+    }),
+    undefined,
+  );
+  assert.equal(normalizeCerts({ claude_101: "XXXXXXXX" }), undefined);
+  assert.equal(normalizeCerts({ claude_101: "000000" }), undefined);
+  // A real code that happens to repeat a character is still fine.
+  assert.deepEqual(normalizeCerts({ claude_101: "bqxyfumtey2e" }), {
+    claude_101: "bqxyfumtey2e",
+  });
+});


### PR DESCRIPTION
## Problem

Builders copy the cert id off the **Skilljar course title**, so frontmatter arrives in every shape. None of these matched the catalog, so each one silently rendered as a grey default medal instead of the badge the builder earned:

| Written in frontmatter | Should be |
|---|---|
| `Introduction to agent skills`, `introduction-to-agent-skills`, `introduction_to_agent_skills`, `agentskills_intro`, `agent_skills` | `agent_skills_intro` |
| `Introduction to subagents`, `introduction_to_subagents`, `subagents` | `subagents_intro` |
| `introduction_to_Model_Context_Protocol`, `introduction_to_model_context_protocol` | `mcp_intro` |
| `AI Fluency Framework and Foundations`, `AI_fluency_framework_&_foundations` | `ai_fluency` |
| `Claude_Platform 101`, `claude_Platform_101` | `claude_platform_101` |
| `claude_cowork_intro` | `claude_cowork` |

**19 profiles** were affected. Nothing warned loudly enough for anyone to notice — the card just showed a generic medal.

Root cause is documentation: `BUILDERS.md`, the file the PR template points builders at, has **no cert section at all**, and the id list in `_example.md` was stale.

## Fix

`canonicalCertId()` resolves an id in three layers:

1. **slugify** — lowercase, every non-alphanumeric run to `_`. Kills case, space, hyphen and `&` variants for free.
2. **`CERT_ALIASES`** — explicit table for wording variants (`introduction_to_subagents` → `subagents_intro`).
3. **catalog label index** — auto-derived from `CERT_CATALOG` labels, so a renamed label keeps resolving.

Unresolved ids are kept as-is and still render. `normalizeCerts()` applies it, so render, `validate-builders` and `verify-certs` all agree on one id. If a builder lists the same cert twice, the canonical spelling wins.

No builder file has to change — aliases resolve at build time.

## Also in here

- **Catalog**: `ai_fluency_for_educators` (already in use, was defaulting) and `git_essential_training` (#348), each with an icon.
- **Bug — `verify-certs.mjs` built the wrong URL.** It used `skilljarUrl(code)`, but non-Skilljar certs store a *full URL* as the code, so every one was checked as `verify.skilljar.com/c/https://www.linkedin.com/...` → 4xx → reported as a **fake cert**. Now `certUrl(code)`. Latent until now because `verify:certs` isn't in `ci.yml`.
- **Bug — placeholder codes rendered as "verified".** `wythwin.md` had the template's `YYYYYYYY`, which passes the code regex and rendered a verified Claude Code 101 badge linking to a 404. Placeholder codes (one repeated character) are now rejected, and the leftover line is removed. `extractUrl` no longer resurrects a rejected Skilljar URL as a "non-Skilljar cert".
- **`haymannko.md`**: certs sat at the top level instead of under `certs:`, so both earned certs were invisible. Nested.
- **`validate-builders`**: now names the canonical id (`'X' resolves to 'Y' — prefer the short id`) instead of a flat "not in catalog".
- **Guide**: new cert section in `BUILDERS.md`, **EN + MY**, with the full course-title → short-id table, where to find your code, and the two rules that actually trip people up (indent under `certs:`, use the short id). `_example.md` list refreshed to match.
- **Tests**: `src/lib/certs.test.mjs`, built from the real ids builders pushed. Added a `test` script — the repo had test files but no runner.

## Verification

```
npm test                  29 passed, 0 failed
npm run format:check      clean
npm run check             0 errors, 0 warnings
npm run validate:builders 167 valid, 0 unresolved cert ids
npm run build             53 pages
npm run verify:certs      186 verified, 0 unreachable, 0 invalid   (live)
```

Spot-checked the built HTML — `kingquiet-bot`, `naitar`, `HlaingThinPhyu`, `myoaung`, `sandar577`, `haymannko` all render named, verified badges instead of default medals.