### PR TITLE
fix(ci): dedupe cert keys in nanaungoo.md

### DIFF
--- a/src/content/builders/nanaungoo.md
+++ b/src/content/builders/nanaungoo.md
@@ -4,30 +4,24 @@ github: nanaungoo
 cohort: 1
 role: builder
 skills: ["Google Antigravity", "Claude Code"]
-website:  https://ud.me/nanaungoo.brave
+website: https://ud.me/nanaungoo.brave
 certs:
   claude_101: https://verify.skilljar.com/c/rsdbx9pzikkk
   claude_code_101: https://verify.skilljar.com/c/sovo9xx54xaz
-  claude_Platform_101: https://verify.skilljar.com/c/o5zev75muxkm
-  claude_cowork_intro: https://verify.skilljar.com/c/wc2vii2gxkmy
-  claude_code_in_action: https://verify.skilljar.com/c/qtu3nqe8qj6x
-  ai_fluency: https://verify.skilljar.com/c/nr4m87ih5snz
-  mcp_intro: https://verify.skilljar.com/c/ydww577oeok7
   agent_skills_intro: https://verify.skilljar.com/c/hi83hjczdzuy
   subagents_intro: https://verify.skilljar.com/c/oh83sinfpszy
   mcp_intro: https://verify.skilljar.com/c/ydww577oeok7
   claude_code_in_action: https://verify.skilljar.com/c/qtu3nqe8qj6x
-  # building_claude_api: https://anthropic.skilljar.com/claude-with-the-anthropic-api
   claude_platform_101: https://verify.skilljar.com/c/o5zev75muxkm
   claude_cowork: https://verify.skilljar.com/c/wc2vii2gxkmy
+  ai_fluency: https://verify.skilljar.com/c/nr4m87ih5snz
+  # building_claude_api: https://anthropic.skilljar.com/claude-with-the-anthropic-api
   # mcp_advanced: https://anthropic.skilljar.com/model-context-protocol-advanced-topics
   # claude_bedrock: https://anthropic.skilljar.com/claude-in-amazon-bedrock
   # claude_vertex: https://anthropic.skilljar.com/claude-with-google-vertex
-  ai_fluency: https://verify.skilljar.com/c/nr4m87ih5snz
   # ai_fluency_for_educators: https://anthropic.skilljar.com/ai-fluency-for-educators
   # github_foundations: https://www.credly.com/badges/github-foundations
   # git_essential_training: https://www.linkedin.com/learning/git-essential-training
-
 ---
 
 From "Zero-Knowledge" to Accidental Coder: My Chaotic Journey. I used to be the definition of a "non-techie." I’d just sit there using apps others built, feeling like a caveman watching magic, until the AI wave hit. I suddenly had this "crazy" realization: Why am I stuck using what others give me? I want to build my own stuff! That’s when I stumbled upon "Antigravity." Back then, it was like the Wild West—no limits, no rules. I was so hyped I was churning out two Android apps a day. Then, I got paranoid about privacy—didn't want to use third-party apps for video calls with my family—so I decided, "I’ll build my own damn video chat app."I grabbed Jitsi, thinking it’d be a breeze. Instead, I fell down the most glorious rabbit hole in history. One minute I’m fiddling with Jitsi, the next I’m spiraling through Cloudflare Workers, Android Studio, and the absolute nightmare that is Gradle. It was a total "how did I get here?" moment. Before I knew it, I was obsessively trying to mimic professional development structures like CLAUDE.md files. My "learning" process? Pure chaos. I’d use Plan Mode, hit a wall, get confused, search for answers, get more confused, and eventually just scream at Antigravity in Burmese until it explained things in a way my brain could actually process. I didn't even know what Git was when I started. My primary debugging strategy? When in doubt, just mash the "Yes" button until something works. I’m a true "Antigravity product." When the Gemini CLI dropped, I installed it just to spam /help commands and read random tech logs for fun.So, here I am—fully caught in a whirlwind of AI, trapped in a beautiful, endless loop of "What the hell am I doing?" and "Wait, I actually made it work!" ကျွန်တော်က ကုတ်ဒင်းဘာညာလဲနားမလည်ဘူး အေအိုင်တွေစပေါ်လာတော့ ငါ့ဖုန်းထဲက သူများလုပ်ပေးထားတဲ့ app တွေသုံးရတာ နဲနဲပိန်းတယ်ခံစားရလို့ ငါသုံးချင်တာ ငါလုပ်သုံးမယ် ဆိုပြီးအရူးထတဲ့အချိန် antigravity စပေါ်လာတာနဲ့ တိုးတာ၊ အဲ့ဒီအချိန်တုန်းက antigravity က limit တွေလဲအများကြီးပေးထားတဲ့အချိန် တစ်ရက်ထဲ android app နှစ်ခုလောက် လုပ်တာ အိမ်နဲ့ video call ပြောရတာ သူများဟာတွေသုံးရတာ စိတ်မသန့်ဘူး ဘာညာဖြစ်တာပေ့ါ အဲ့တော့ ကိုယ်တိုင် video chat app လုပ်မယ်ဆိုပြီး ကိုကိုရဲတို့ online varcamp လုပ်တုန်းက သုံးခိုင်းတဲ့ https://jitsi.org/projects/ ဆိုတဲ့ဟာကိုယူပြီးကလိကြည့်တာ အဲ့ဒီမှာ စပြီး cloudflare worker တွေစီရောက်၊ android studio တွေစီရောက် Gradle တွေရောက် ဟိုရောက်ဒီရောက်နဲ့ ဒီနေ့သင့်တဲ့ပေးတဲ့ CLAUDE.md ပုံစံမျိုးတွေကို ကိုယ်တိုင်ပုံဖော်မိဖို့ကြိုးစားမိနေတာ ကျွန်တော့အတွက်တော့ plan mode ဆိုတာ  သူကပြောပြလိုက် မသိတာတွေပါလာလိုက် ထပ်ရှာလိုက်နဲ့အရမ်းသင်ပေးတာ နောက်ဆုံး english လိုနားမလည်လို့ မြန်မာလိုပါပြောဆိုပြီး antigravity ထဲမှာ ကြုံးတာ၊ စလုပ်တုန်းက git လဲမသိဘူး ဘာမှမသိဘူး၊ သူပြောလိုက်ဖတ်လိုက် နားမလည်ရင် လုပ်ကွာဆိုပြီး yes တွေကြည့်ပဲဖိနှိပ်တာ၊ ကျွန်တော်က antigravity လက်ထွက်ဆိုတော့ gemini cli ဆိုပြီးထပ်ပေါ်လာတော့ သွင်းပြီး အလကားနေရင် /help တွေနှိပ်ပြီးလိုက်ဖတ်တာ ထင်ရာတွေလုပ်တာ၊ အဲ့ဒါနဲ့ အခု antigravity နဲ့လုံးလည်ချာလည် လိုက်နေတာပါ၊


### PR DESCRIPTION
main CI is red since #376: `astro check` fails with `duplicated mapping key` at `src/content/builders/nanaungoo.md:17`.

The `certs:` map listed `mcp_intro`, `claude_code_in_action` and `ai_fluency` twice, plus `claude_Platform_101` / `claude_cowork_intro` alongside the canonical `claude_platform_101` / `claude_cowork`. js-yaml rejects exact duplicate keys.

Kept one canonical entry per cert — same verify codes, no certs lost.

Verified locally: `format:check`, `check` (0 errors), `validate:builders`, `build` all pass.