### PR TITLE
Fix CI: quote cert key with a colon in aungkyawminhtet.md

### DIFF
--- a/src/content/builders/aungkyawminhtet.md
+++ b/src/content/builders/aungkyawminhtet.md
@@ -7,7 +7,7 @@ skills: ["React", "TypeScript", "Next.js", "Node.js", "Claude Code", ]
 repo: https://github.com/aungkyawminhtet
 linkedin: https://www.linkedin.com/in/aung-kyaw-min-htet-3b359b23b/
 certs:
-  AI Fluency: Framework & Foundations: https://verify.skilljar.com/c/phatovsc5u2t
+  "AI Fluency: Framework & Foundations": https://verify.skilljar.com/c/phatovsc5u2t
   Claude Code in Action: https://verify.skilljar.com/c/ep76ko6o4qci
 ---
 


### PR DESCRIPTION
`main` is red and the Pages deploy is failing. `astro build` dies in content sync:

```
bad indentation of a mapping entry
  Location: src/content/builders/aungkyawminhtet.md:9:37
```

## Cause

The cert name contains a colon and was written unquoted, so YAML reads `AI Fluency` as the key and chokes on the remainder of the line:

```yaml
certs:
  AI Fluency: Framework & Foundations: https://verify.skilljar.com/c/phatovsc5u2t
```

Introduced by #375, which was merged with a failing `check` run.

## Fix

Quote the key. The cert resolves identically — `slugifyCertId` maps both this spelling and the `AI Fluency Framework and Foundations` form other builders use to the same catalog id `ai_fluency`, so the rendered badge is unchanged.

## Test plan

- [x] Frontmatter parses; `certs` keys resolve to `ai_fluency` and `claude_code_in_action`
- [x] `npm run format:check` clean
- [x] `npm run check` — 0 errors
- [x] `npm run validate:builders` — no new findings (remaining notes are pre-existing, on other profiles, non-fatal)
- [x] `npm run build` — 53 pages, previously failed
- [x] Scanned all 167 builder profiles: this was the only one with unparseable frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2uD85EqyehUnaLQWt7oRw