### PR TITLE
Update certification links in heinhtet-zaw12.md

### DIFF
--- a/src/content/builders/heinhtet-zaw12.md
+++ b/src/content/builders/heinhtet-zaw12.md
@@ -8,7 +8,10 @@ linkedin: https://www.linkedin.com/in/hein-htet-zaw-8422413b5
 certs:
   claude_101: https://verify.skilljar.com/c/22dk9woa7soe
   claude_code_101: https://verify.skilljar.com/c/x232wgytjqdb
+  claude_platform_101: https://verify.skilljar.com/c/rxm87yn6fpmd
   agent_skills_intro: https://verify.skilljar.com/c/djbjkpto925v
+  subagents_intro: https://anthropic.skilljar.com/introduction-to-subagents
+  mcp_intro: https://verify.skilljar.com/c/euyqun3oj935
 ---
 
 <!-- TODO(heinhtet-zaw12): add repo / x / website when available -->


### PR DESCRIPTION
Added new certification links for Claude Platform 101 and Subagents Intro.

<!-- Builder PR? Check the boxes below. Other PRs: delete this template. -->

## Adding myself as a Builder

- [ ] Added **one** file: `src/content/builders/<my-github-username>.md`
- [ ] Filename matches my `github:` value
- [ ] Filled `name`, `github`, `cohort`
- [ ] Wrote a 2–3 sentence intro below the frontmatter
- [ ] Did **not** change any other files

<!-- See BUILDERS.md for the full guide. -->
