### PR TITLE
Add certification links to khinmyatthu2193.md

### DIFF
--- a/src/content/builders/khinmyatthu2193.md
+++ b/src/content/builders/khinmyatthu2193.md
@@ -7,6 +7,11 @@ role: builder
 skills: ["JavaScript", "Python", "React", "React Native", "Firebase", "Django", "Claude Code"]
 
 repo: https://github.com/khinmyatthu2193
+certs:
+  ai_fluency: https://verify.skilljar.com/c/3yuvuevbz58d
+  claude_101: https://verify.skilljar.com/c/2e3m9ph7v2jb
+  claude_code_101: https://verify.skilljar.com/c/2cj7h4upxrc7
+  claude_code_in_action: https://verify.skilljar.com/c/zm4owcmcyraw
 linkedin: https://www.linkedin.com/in/khin-myat-thu-837892352/
 
 ---


### PR DESCRIPTION
Added certification links for AI fluency and Claude courses.

<!-- Builder PR? Check the boxes below. Other PRs: delete this template. -->

## Adding myself as a Builder

- [x ] Added **one** file: `src/content/builders/<my-github-username>.md`
- [x ] Filename matches my `github:` value
- [x ] Filled `name`, `github`, `cohort`
- [x ] Wrote a 2–3 sentence intro below the frontmatter
- [x ] Did **not** change any other files

<!-- See BUILDERS.md for the full guide. -->
